### PR TITLE
Change to how --default-dump-config works

### DIFF
--- a/vai/__init__.py
+++ b/vai/__init__.py
@@ -101,7 +101,7 @@ def main():
                 print("Operation will overwrite existing config file. Do you want to do this? (Y/n)", end=' ')
                 if input().lower() in ('no', 'n'):
                     sys.exit(1)
-			os.remove(filename)
+            os.remove(filename)
             models.Configuration.save()
             print("Dumped default configuration in %s" % filename)
             sys.exit(0)

--- a/vai/__init__.py
+++ b/vai/__init__.py
@@ -97,13 +97,13 @@ def main():
             print("Dumped default configuration in %s" % filename)
             sys.exit(0)
             '''
-			if os.path.exists(filename):
-				print("Operation will overwrite existing config file. Do you want to do this? (Y/n)", end=' ')
-				if input().lower() in ('no', 'n'):
-					sys.exit(1)
-			models.Configuration.save()
-			print("Dumped default configuration in %s" % filename)
-			sys.exit(0)
+            if os.path.exists(filename):
+                print("Operation will overwrite existing config file. Do you want to do this? (Y/n)", end=' ')
+                if input().lower() in ('no', 'n'):
+                    sys.exit(1)
+            models.Configuration.save()
+            print("Dumped default configuration in %s" % filename)
+            sys.exit(0)
         app = EditorApp.EditorApp(sys.argv)
         if args.filename:
             app.openFile(args.filename)

--- a/vai/__init__.py
+++ b/vai/__init__.py
@@ -88,15 +88,6 @@ def main():
 
         if args.dump_default_config:
             filename = models.Configuration.filename()
-            '''
-            if os.path.exists(filename):
-                print("Refusing to overwrite existing config file %s. Delete the file manually and try again." % filename)
-                sys.exit(1)
-
-            models.Configuration.save()
-            print("Dumped default configuration in %s" % filename)
-            sys.exit(0)
-            '''
             if os.path.exists(filename):
                 print("Operation will overwrite existing config file. Do you want to do this? (Y/n)", end=' ')
                 if input().lower() in ('no', 'n'):

--- a/vai/__init__.py
+++ b/vai/__init__.py
@@ -88,6 +88,7 @@ def main():
 
         if args.dump_default_config:
             filename = models.Configuration.filename()
+			'''
             if os.path.exists(filename):
                 print("Refusing to overwrite existing config file %s. Delete the file manually and try again." % filename)
                 sys.exit(1)
@@ -95,6 +96,14 @@ def main():
             models.Configuration.save()
             print("Dumped default configuration in %s" % filename)
             sys.exit(0)
+			'''
+			if os.path.exists(filename):
+				print("Operation will overwrite existing config file. Do you want to do this? (Y/n)", end=' ')
+				if input().lower() in ('no', 'n'):
+					sys.exit(1)
+			models.Configuration.save()
+			print("Dumped default configuration in %s" % filename)
+			sys.exit(0)
         app = EditorApp.EditorApp(sys.argv)
         if args.filename:
             app.openFile(args.filename)

--- a/vai/__init__.py
+++ b/vai/__init__.py
@@ -101,6 +101,7 @@ def main():
                 print("Operation will overwrite existing config file. Do you want to do this? (Y/n)", end=' ')
                 if input().lower() in ('no', 'n'):
                     sys.exit(1)
+			os.remove(filename)
             models.Configuration.save()
             print("Dumped default configuration in %s" % filename)
             sys.exit(0)

--- a/vai/__init__.py
+++ b/vai/__init__.py
@@ -88,7 +88,7 @@ def main():
 
         if args.dump_default_config:
             filename = models.Configuration.filename()
-			'''
+            '''
             if os.path.exists(filename):
                 print("Refusing to overwrite existing config file %s. Delete the file manually and try again." % filename)
                 sys.exit(1)
@@ -96,7 +96,7 @@ def main():
             models.Configuration.save()
             print("Dumped default configuration in %s" % filename)
             sys.exit(0)
-			'''
+            '''
 			if os.path.exists(filename):
 				print("Operation will overwrite existing config file. Do you want to do this? (Y/n)", end=' ')
 				if input().lower() in ('no', 'n'):

--- a/vai/__init__.py
+++ b/vai/__init__.py
@@ -90,7 +90,7 @@ def main():
             filename = models.Configuration.filename()
             if os.path.exists(filename):
                 print("Operation will overwrite existing config file. Do you want to do this? (Y/n)", end=' ')
-                if input().lower() in ('no', 'n'):
+                if input().lower() in ('yes', 'y'):
                     sys.exit(1)
             os.remove(filename)
             models.Configuration.save()


### PR DESCRIPTION
I feel like the current functionality of --default-dump-config, where it fails if vimrc exists and requires the user to delete it themselves, is a bit clunky.  Simply warning the user, and then deleting vimrc and replacing it (I tried having it overwrite, but that doesn't seem to work), seems a lot nicer, and more in line with what other programs might do.  I hope you like my proposed change.

-Morgan