### PR TITLE
docs: Fix a few typos

### DIFF
--- a/RATIONALE.rst
+++ b/RATIONALE.rst
@@ -2,7 +2,7 @@ Rationale
 =========
 
 A most frequent question I've been asked is "why not NeoVim?". 
-Before starting vai, and more or less a month before the annoucement of neovim,
+Before starting vai, and more or less a month before the announcement of neovim,
 I put my nose in the vim source code to see if I could implement the features I wanted
 directly into vim. Here were my findings
 

--- a/docs/WritingPlugins.rst
+++ b/docs/WritingPlugins.rst
@@ -51,7 +51,7 @@ The Module file DeepBlue.py must define a class instance of ``sdk.SyntaxColorsPl
 This class must define three methods:
 
     - ``name(self)`` Returns the name of the plugin as a string.
-    - ``supportsNumColors(self, num_colors)`` returns True if the plugin supports the passed amount of colors. If you develop a purely 8 colors plugin, return True only if num_colors is 8, False otherwisee
+    - ``supportsNumColors(self, num_colors)`` returns True if the plugin supports the passed amount of colors. If you develop a purely 8 colors plugin, return True only if num_colors is 8, False otherwise
    
     - ``colorSchema(self, num_colors)`` this is the business end of the class. It must return a dictionary associating syntax tokens to colors.
 


### PR DESCRIPTION
There are small typos in:
- RATIONALE.rst
- docs/WritingPlugins.rst

Fixes:
- Should read `otherwise` rather than `otherwisee`.
- Should read `announcement` rather than `annoucement`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md